### PR TITLE
Better processing of PNG heightmap import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# IntelliJ project files
+.idea
+*.iml
+out
+maps/

--- a/src/net/buddat/wgenerator/HeightMap.java
+++ b/src/net/buddat/wgenerator/HeightMap.java
@@ -2,6 +2,7 @@ package net.buddat.wgenerator;
 
 import java.awt.image.BufferedImage;
 import java.awt.image.DataBufferUShort;
+import java.awt.image.Raster;
 import java.awt.image.WritableRaster;
 import java.io.File;
 import java.io.IOException;
@@ -83,18 +84,17 @@ public class HeightMap {
 		}
 
 		long startTime = System.currentTimeMillis();
-
 		try {
-			DataBufferUShort buffer = (DataBufferUShort) heightImage.getRaster().getDataBuffer();
+            Raster data = heightImage.getData();
 
-			int[][] array = new int[mapSize][mapSize];
+            for (int x = 0; x < mapSize; x++) {
+                for (int y = 0; y < mapSize; y++) {
 
-			for (int x = 0; x < mapSize; x++) {
-				for (int y = 0; y < mapSize; y++) {
+                    double[] dArray = null;
 
-					array[x][y] = buffer.getElem(x + y * mapSize);
+                    dArray = data.getPixel(x,y, dArray);
 
-					setHeight(x, y, getHeight(x, y) + (array[x][y] / 65536f), false);
+					setHeight(x, y, getHeight(x, y) + (dArray[0] / 65536f), false);
 				}
 			}
 


### PR DESCRIPTION
I had problems with processing of PNG16 exported from World Creator, because your method did not account for the alpha channel, which produced very nasty lines in the imported heightmap. I modified the PNG -> heightMap method to get values from pixels from Raster class.

The double array produced by the getPixel() method produces 3 equal numbers and alpha, so it is enough to take the value of the first channel for processing.